### PR TITLE
[+]Fix: 修复victim节点异常退出导致的admin节点死锁

### DIFF
--- a/admin/cli/interactive.go
+++ b/admin/cli/interactive.go
@@ -103,6 +103,9 @@ func Interactive() {
 			fmt.Println("node", tmpNodeID)
 			if _, ok := node.GNodeInfo.NodeNumber2UUID[tmpNodeID]; ok {
 				nodeID = tmpNodeID
+			} else if tmpNodeID == 0 {
+				currentPeerNodeHashID = ""
+				break
 			} else {
 				fmt.Println("unknown node id.")
 				break


### PR DESCRIPTION
同时添加了`goto`指令中`admin <=> 0`的绑定